### PR TITLE
Move charset setting to .editorconfig root

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,10 +1,10 @@
 root = true
+charset = utf-8
 
 # All files
 [*]
 end_of_line = lf
 indent_style = space
-charset = utf-8
 
 # Xml files
 [*.xml]


### PR DESCRIPTION
I bumped into an issue with dotnet format.
See: https://github.com/dotnet/sdk/issues/46780